### PR TITLE
Fix/minor

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -3,8 +3,8 @@
 @section('content')
 
     {{-- Hero Section --}}
-    <section class="relative bg-cover bg-center h-[300px] flex items-center justify-center text-white"
-        style="background-image: url('{{ asset('sekolah.png') }}')">
+    <section class="relative bg-cover bg-center h-[300px] flex items-center justify-center text-white pt-16"
+             style="background-image: url('{{ asset('sekolah.png') }}')">
         <div class="bg-black bg-opacity-50 p-6 rounded-lg text-center">
             <h1 class="text-3xl md:text-4xl font-bold">Tentang SMP Negeri 1 Cibadak</h1>
             <p class="mt-2 text-sm md:text-base">Sejarah, Profil, Visi dan Misi</p>
@@ -65,36 +65,36 @@
                 <div class="overflow-x-auto">
                     <table class="w-full border border-gray-200">
                         <thead class="bg-blue-600 text-white">
-                            <tr>
-                                <th class="p-2">Kelas</th>
-                                <th class="p-2">Laki-laki</th>
-                                <th class="p-2">Perempuan</th>
-                                <th class="p-2">Jumlah</th>
-                                <th class="p-2">Jumlah Rombel</th>
-                            </tr>
+                        <tr>
+                            <th class="p-2">Kelas</th>
+                            <th class="p-2">Laki-laki</th>
+                            <th class="p-2">Perempuan</th>
+                            <th class="p-2">Jumlah</th>
+                            <th class="p-2">Jumlah Rombel</th>
+                        </tr>
                         </thead>
                         <tbody>
-                            <tr class="text-center border-b">
-                                <td class="p-2">VII</td>
-                                <td class="p-2">140</td>
-                                <td class="p-2">196</td>
-                                <td class="p-2">336</td>
-                                <td class="p-2">8</td>
-                            </tr>
-                            <tr class="text-center border-b bg-gray-50">
-                                <td class="p-2">VIII</td>
-                                <td class="p-2">140</td>
-                                <td class="p-2">196</td>
-                                <td class="p-2">336</td>
-                                <td class="p-2">8</td>
-                            </tr>
-                            <tr class="text-center border-b">
-                                <td class="p-2">IX</td>
-                                <td class="p-2">140</td>
-                                <td class="p-2">196</td>
-                                <td class="p-2">336</td>
-                                <td class="p-2">8</td>
-                            </tr>
+                        <tr class="text-center border-b">
+                            <td class="p-2">VII</td>
+                            <td class="p-2">140</td>
+                            <td class="p-2">196</td>
+                            <td class="p-2">336</td>
+                            <td class="p-2">8</td>
+                        </tr>
+                        <tr class="text-center border-b bg-gray-50">
+                            <td class="p-2">VIII</td>
+                            <td class="p-2">140</td>
+                            <td class="p-2">196</td>
+                            <td class="p-2">336</td>
+                            <td class="p-2">8</td>
+                        </tr>
+                        <tr class="text-center border-b">
+                            <td class="p-2">IX</td>
+                            <td class="p-2">140</td>
+                            <td class="p-2">196</td>
+                            <td class="p-2">336</td>
+                            <td class="p-2">8</td>
+                        </tr>
                         </tbody>
                     </table>
                 </div>
@@ -111,7 +111,8 @@
             <div class="bg-white shadow rounded-lg p-6">
                 <h3 class="text-lg font-semibold mb-2">Visi</h3>
                 <p class="text-gray-700">
-                    Membentuk pembelajar yang akhlakul karimah, berilmu, beretika, berwawasan lingkungan untuk menuju pentas dunia.
+                    Membentuk pembelajar yang akhlakul karimah, berilmu, beretika, berwawasan lingkungan untuk menuju
+                    pentas dunia.
                 </p>
             </div>
             <div class="bg-white shadow rounded-lg p-6">
@@ -139,7 +140,8 @@
             <div class="bg-blue-600 text-white p-6 rounded-lg text-center">
                 <h3 class="text-lg font-semibold mb-2">Strategi</h3>
                 <p>
-                    Tiada kekayaan yang paling utama daripada kekayaan jiwa, tiada kepapaan yang paling menyedihkan daripada kebodohan, dan tiada warisan paling baik daripada pendidikan.
+                    Tiada kekayaan yang paling utama daripada kekayaan jiwa, tiada kepapaan yang paling menyedihkan
+                    daripada kebodohan, dan tiada warisan paling baik daripada pendidikan.
                 </p>
             </div>
         </div>

--- a/resources/views/activities.blade.php
+++ b/resources/views/activities.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Hero Section --}}
     <section class="relative bg-cover bg-center h-[250px] flex items-center justify-center text-white pt-16"
-        style="background-image: url('{{ asset('sekolah.png') }}')">
+             style="background-image: url('{{ asset('sekolah.png') }}')">
         <div class="bg-black bg-opacity-50 p-6 rounded-lg text-center">
             <h1 class="text-3xl md:text-4xl font-bold">Kegiatan SMP Negeri 1 Cibadak</h1>
             <p class="mt-2 text-sm md:text-base">Beberapa Kegiatan di SMP Negeri 1 Cibadak</p>
@@ -13,42 +13,51 @@
 
     {{-- Daftar Kegiatan --}}
     <section class="container mx-auto px-6 py-12">
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            @foreach($activities as $activity)
-                <div class="bg-white shadow rounded-lg overflow-hidden">
-                    <div class="relative h-48">
-                        @if($activity->image)
-                            <img src="{{ asset('storage/' . $activity->image) }}" alt="{{ $activity->title }}" 
-                                class="w-full h-full object-cover">
-                        @else
-                            <div class="w-full h-full bg-gray-200 flex items-center justify-center">
-                                <span class="text-gray-500">No Image</span>
+        @if($activities->isEmpty())
+            <div class="flex flex-col items-center justify-center bg-gray-50 rounded-lg shadow p-6 min-h-[400px]">
+                <i class="fas fa-calendar-alt text-gray-400 text-6xl mb-4"></i>
+                <h2 class="text-gray-600 text-xl font-semibold">Tidak Ada Kegiatan</h2>
+                <p class="text-gray-500 mt-2">Belum ada kegiatan yang tersedia saat ini.</p>
+            </div>
+        @else
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                @foreach($activities as $activity)
+                    <div class="bg-white shadow rounded-lg overflow-hidden">
+                        <div class="relative h-48">
+                            @if($activity->image)
+                                <img src="{{ asset('storage/' . $activity->image) }}" alt="{{ $activity->title }}"
+                                     class="w-full h-full object-cover">
+                            @else
+                                <div class="w-full h-full bg-gray-200 flex items-center justify-center">
+                                    <span class="text-gray-500">No Image</span>
+                                </div>
+                            @endif
+                            <div
+                                class="absolute bottom-0 w-full bg-blue-600 bg-opacity-80 px-4 py-2 text-white font-semibold">
+                                {{ $activity->title }}
                             </div>
-                        @endif
-                        <div class="absolute bottom-0 w-full bg-blue-600 bg-opacity-80 px-4 py-2 text-white font-semibold">
-                            {{ $activity->title }}
+                        </div>
+                        <div class="p-4">
+                            <p class="text-gray-600 text-sm mb-3">
+                                {{ \Carbon\Carbon::parse($activity->date)->format('d F Y') }}
+                            </p>
+                            <p class="text-gray-700 mb-3 line-clamp-3">
+                                {{ Str::limit(strip_tags($activity->description), 100) }}
+                            </p>
+                            <a href="{{ route('activities.detail', $activity->id) }}"
+                               class="text-blue-600 font-semibold hover:underline">
+                                Lihat Kegiatan
+                            </a>
                         </div>
                     </div>
-                    <div class="p-4">
-                        <p class="text-gray-600 text-sm mb-3">
-                            {{ \Carbon\Carbon::parse($activity->date)->format('d F Y') }}
-                        </p>
-                        <p class="text-gray-700 mb-3 line-clamp-3">
-                            {{ Str::limit(strip_tags($activity->description), 100) }}
-                        </p>
-                        <a href="{{ route('activities.detail', $activity->id) }}" 
-                           class="text-blue-600 font-semibold hover:underline">
-                            Lihat Kegiatan
-                        </a>
-                    </div>
-                </div>
-            @endforeach
-        </div>
+                @endforeach
+            </div>
 
-        {{-- Pagination --}}
-        <div class="mt-8 flex justify-center">
-            {{ $activities->links() }}
-        </div>
+            {{-- Pagination --}}
+            <div class="mt-8 flex justify-center">
+                {{ $activities->links() }}
+            </div>
+        @endif
     </section>
 
 @endsection

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -1,4 +1,4 @@
-<nav class="bg-white shadow-md w-full z-50">
+<nav class="bg-white shadow-md fixed top-0 w-full z-50">
     <div class="container mx-auto flex justify-between items-center px-6 py-4">
         <div class="flex items-center">
             <img src="{{ asset('logo.png') }}" alt="Logo" class="h-10 mr-3">

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -18,7 +18,7 @@
             <li><a href="{{ route('contact') }}"
                    class="{{ request()->routeIs('contact') ? 'text-blue-600' : 'hover:text-blue-600' }}">Kontak</a></li>
         </ul>
-        <button id="menu-toggle" class="md:hidden text-gray-700 focus:outline-none">
+        <button id="menu-toggle" class="md:hidden text-gray-700 focus:outline-none hover:cursor-pointer">
             <!-- Icon menu mobile -->
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     {{-- Hero Section --}}
-    <section class="relative bg-cover bg-center h-[250px] flex items-center justify-center text-white"
+    <section class="relative bg-cover bg-center h-[250px] flex items-center justify-center text-white pt-16"
              style="background-image: url('{{ asset('sekolah.png') }}')">
         <div class="bg-black bg-opacity-50 p-6 rounded-lg text-center">
             <h1 class="text-3xl md:text-4xl font-bold">Kontak Kami</h1>

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -3,12 +3,12 @@
 @section('content')
 
     {{-- Hero Section --}}
-    <section class="relative bg-cover bg-center h-[500px] flex items-center justify-center text-white"
-        style="background-image: url('{{ asset('sekolah.png') }}')">
+    <section class="relative bg-cover bg-center h-[500px] flex items-center justify-center text-white pt-16"
+             style="background-image: url('{{ asset('sekolah.png') }}')">
         <div class="bg-black bg-opacity-50 p-6 rounded-lg text-center">
             <h1 class="text-3xl font-bold mb-4">MOTTO</h1>
             <p class="max-w-2xl mx-auto">
-                SMPN 1 Cibadak (Cerdas Beretika) Ceria, Empati, Rasional, Damai, Aktif, Sabar, Bersih, Elok, 
+                SMPN 1 Cibadak (Cerdas Beretika) Ceria, Empati, Rasional, Damai, Aktif, Sabar, Bersih, Elok,
                 Tulus, Iman, Konsisten, Amanah.
             </p>
             <a href="/kontak" class="mt-6 inline-block bg-blue-600 px-6 py-2 rounded-lg hover:bg-blue-700">
@@ -25,10 +25,15 @@
         <div class="flex flex-col justify-center">
             <h2 class="text-2xl font-bold mb-4">Sambutan Kepala Sekolah SMP Negeri 1 Cibadak</h2>
             <p class="text-gray-700">
-            Puji dan syukur mari kita panjatkan ke hadirat Allah SWT, Tuhan Yang Maha Esa, yang senantiasa dengan kasih dan sayang-Nya melimpahkan berbagai nikmat dan karunia kepada kita semua. Shalawat serta salam semoga tetap tercurah kepada junjungan kita Nabi Muhammad SAW, keluarga, sahabat, dan para pengikutnya hingga akhir zaman.
+                Puji dan syukur mari kita panjatkan ke hadirat Allah SWT, Tuhan Yang Maha Esa, yang senantiasa dengan
+                kasih dan sayang-Nya melimpahkan berbagai nikmat dan karunia kepada kita semua. Shalawat serta salam
+                semoga tetap tercurah kepada junjungan kita Nabi Muhammad SAW, keluarga, sahabat, dan para pengikutnya
+                hingga akhir zaman.
             </p>
             <p class="text-gray-700">
-            Dengan rasa bangga dan penuh rasa syukur, saya menyambut kehadiran Anda di website resmi [Nama Sekolah], sebuah media informasi dan komunikasi yang kami hadirkan untuk memperkenalkan profil sekolah, kegiatan, serta berbagai pencapaian yang telah diraih.
+                Dengan rasa bangga dan penuh rasa syukur, saya menyambut kehadiran Anda di website resmi [Nama Sekolah],
+                sebuah media informasi dan komunikasi yang kami hadirkan untuk memperkenalkan profil sekolah, kegiatan,
+                serta berbagai pencapaian yang telah diraih.
             </p>
         </div>
     </section>

--- a/resources/views/news.blade.php
+++ b/resources/views/news.blade.php
@@ -4,7 +4,7 @@
 
     {{-- Hero Section --}}
     <section class="relative bg-cover bg-center h-[250px] flex items-center justify-center text-white pt-16"
-        style="background-image: url('{{ asset('sekolah.png') }}')">
+             style="background-image: url('{{ asset('sekolah.png') }}')">
         <div class="bg-black bg-opacity-50 p-6 rounded-lg text-center">
             <h1 class="text-3xl md:text-4xl font-bold">Berita</h1>
             <p class="mt-2 text-sm md:text-base">Berita Terkini SMP Negeri 1 Cibadak</p>
@@ -13,109 +13,123 @@
 
     {{-- Berita Baru --}}
     <section class="container mx-auto px-6 py-12">
-        <div class="flex justify-between items-center mb-6">
-            <h2 class="text-2xl font-bold">Berita Terbaru</h2>
-        </div>
-
-        <div class="grid md:grid-cols-3 gap-6">
-            @foreach($news as $item)
-                <div class="bg-white shadow rounded-lg overflow-hidden">
-                    @if($item->image)
-                        <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}" class="w-full h-40 object-cover">
-                    @else
-                        <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
-                            <span class="text-gray-500">No Image</span>
-                        </div>
-                    @endif
-                    <div class="p-4">
-                        <h3 class="font-semibold text-lg mb-2">{{ $item->title }}</h3>
-                        <p class="text-gray-500 text-sm mb-2">
-                            {{ $item->published_at ? \Carbon\Carbon::parse($item->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
-                        </p>
-                        <p class="text-gray-600 text-sm mb-2 line-clamp-2">
-                            {{ Str::limit(strip_tags($item->content), 100) }}
-                        </p>
-                        <a href="{{ route('news.detail', $item->id) }}" class="text-blue-600 font-medium hover:underline">
-                            Selengkapnya...
-                        </a>
-                    </div>
-                </div>
-            @endforeach
-        </div>
-    </section>
-
-    {{-- Highlight Berita --}}
-    @if($highlight)
-    <section class="bg-gray-100 py-12">
-        <div class="container mx-auto px-6">
-            <h2 class="text-2xl font-bold mb-6">Sorotan</h2>
-            <div class="grid md:grid-cols-2 gap-6 items-center">
-                @if($highlight->image)
-                    <img src="{{ asset('storage/'.$highlight->image) }}" alt="{{ $highlight->title }}" class="w-full rounded-lg shadow">
-                @else
-                    <div class="w-full h-64 bg-gray-200 flex items-center justify-center rounded-lg">
-                        <span class="text-gray-500">No Image</span>
-                    </div>
-                @endif
-                <div>
-                    <h2 class="text-2xl font-bold mb-3">{{ $highlight->title }}</h2>
-                    <p class="text-gray-500 text-sm mb-2">
-                        {{ $highlight->published_at ? \Carbon\Carbon::parse($highlight->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
-                    </p>
-                    <p class="text-gray-700 mb-4">{{ Str::limit(strip_tags($highlight->content), 150) }}</p>
-                    <a href="{{ route('news.detail', $highlight->id) }}" 
-                       class="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-                       Baca Selengkapnya
-                    </a>
-                </div>
+        @if($news->isEmpty() && !$highlight && $moreNews->isEmpty() && $recentPosts->isEmpty())
+            <div class="flex flex-col items-center justify-center bg-gray-50 rounded-lg shadow p-6 min-h-[400px]">
+                <i class="fas fa-newspaper text-gray-400 text-6xl mb-4"></i>
+                <h2 class="text-gray-600 text-xl font-semibold">Tidak Ada Berita</h2>
+                <p class="text-gray-500 mt-2">Belum ada berita yang tersedia saat ini.</p>
             </div>
-        </div>
-    </section>
-    @endif
+        @else
+            {{-- Berita Baru --}}
+            <div class="flex justify-between items-center mb-6">
+                <h2 class="text-2xl font-bold">Berita Terbaru</h2>
+            </div>
 
-    {{-- Berita Lainnya --}}
-    @if($moreNews->count() > 0)
-    <section class="container mx-auto px-6 py-12">
-        <h2 class="text-2xl font-bold mb-6">Berita Lainnya</h2>
-        <div class="grid md:grid-cols-3 gap-6">
-            @foreach($moreNews as $item)
-                <div class="bg-white shadow rounded-lg overflow-hidden">
-                    @if($item->image)
-                        <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}" class="w-full h-40 object-cover">
-                    @else
-                        <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
-                            <span class="text-gray-500">No Image</span>
+            <div class="grid md:grid-cols-3 gap-6">
+                @foreach($news as $item)
+                    <div class="bg-white shadow rounded-lg overflow-hidden">
+                        @if($item->image)
+                            <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}"
+                                 class="w-full h-40 object-cover">
+                        @else
+                            <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
+                                <span class="text-gray-500">No Image</span>
+                            </div>
+                        @endif
+                        <div class="p-4">
+                            <h3 class="font-semibold text-lg mb-2">{{ $item->title }}</h3>
+                            <p class="text-gray-500 text-sm mb-2">
+                                {{ $item->published_at ? \Carbon\Carbon::parse($item->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
+                            </p>
+                            <p class="text-gray-600 text-sm mb-2 line-clamp-2">
+                                {{ Str::limit(strip_tags($item->content), 100) }}
+                            </p>
+                            <a href="{{ route('news.detail', $item->id) }}"
+                               class="text-blue-600 font-medium hover:underline">
+                                Selengkapnya...
+                            </a>
                         </div>
-                    @endif
-                    <div class="p-4">
-                        <h3 class="font-semibold text-lg mb-2">{{ $item->title }}</h3>
-                        <p class="text-gray-500 text-sm mb-2">
-                            {{ $item->published_at ? \Carbon\Carbon::parse($item->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
-                        </p>
-                        <p class="text-gray-600 text-sm mb-2 line-clamp-2">{{ Str::limit(strip_tags($item->content), 100) }}</p>
-                        <a href="{{ route('news.detail', $item->id) }}" class="text-blue-600 font-medium hover:underline">
-                            Selengkapnya...
-                        </a>
                     </div>
-                </div>
-            @endforeach
-        </div>
-    </section>
-    @endif
+                @endforeach
+            </div>
 
-    {{-- Recent Post --}}
-    @if($recentPosts->count() > 0)
-    <section class="container mx-auto px-6 py-12">
-        <h2 class="text-xl font-bold mb-4">Berita Terkini</h2>
-        <div class="flex flex-wrap gap-3">
-            @foreach($recentPosts as $post)
-                <a href="{{ route('news.detail', $post->id) }}"
-                   class="px-4 py-2 border border-gray-300 rounded-full text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-600">
-                    {{ $post->title }}
-                </a>
-            @endforeach
-        </div>
+            {{-- Highlight Berita --}}
+            @if($highlight)
+                <section class="bg-gray-100 py-12">
+                    <div class="container mx-auto px-6">
+                        <h2 class="text-2xl font-bold mb-6">Sorotan</h2>
+                        <div class="grid md:grid-cols-2 gap-6 items-center">
+                            @if($highlight->image)
+                                <img src="{{ asset('storage/'.$highlight->image) }}" alt="{{ $highlight->title }}"
+                                     class="w-full rounded-lg shadow">
+                            @else
+                                <div class="w-full h-64 bg-gray-200 flex items-center justify-center rounded-lg">
+                                    <span class="text-gray-500">No Image</span>
+                                </div>
+                            @endif
+                            <div>
+                                <h2 class="text-2xl font-bold mb-3">{{ $highlight->title }}</h2>
+                                <p class="text-gray-500 text-sm mb-2">
+                                    {{ $highlight->published_at ? \Carbon\Carbon::parse($highlight->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
+                                </p>
+                                <p class="text-gray-700 mb-4">{{ Str::limit(strip_tags($highlight->content), 150) }}</p>
+                                <a href="{{ route('news.detail', $highlight->id) }}"
+                                   class="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+                                    Baca Selengkapnya
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            @endif
+
+            {{-- Berita Lainnya --}}
+            @if($moreNews->count() > 0)
+                <section class="container mx-auto px-6 py-12">
+                    <h2 class="text-2xl font-bold mb-6">Berita Lainnya</h2>
+                    <div class="grid md:grid-cols-3 gap-6">
+                        @foreach($moreNews as $item)
+                            <div class="bg-white shadow rounded-lg overflow-hidden">
+                                @if($item->image)
+                                    <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}"
+                                         class="w-full h-40 object-cover">
+                                @else
+                                    <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
+                                        <span class="text-gray-500">No Image</span>
+                                    </div>
+                                @endif
+                                <div class="p-4">
+                                    <h3 class="font-semibold text-lg mb-2">{{ $item->title }}</h3>
+                                    <p class="text-gray-500 text-sm mb-2">
+                                        {{ $item->published_at ? \Carbon\Carbon::parse($item->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
+                                    </p>
+                                    <p class="text-gray-600 text-sm mb-2 line-clamp-2">{{ Str::limit(strip_tags($item->content), 100) }}</p>
+                                    <a href="{{ route('news.detail', $item->id) }}"
+                                       class="text-blue-600 font-medium hover:underline">
+                                        Selengkapnya...
+                                    </a>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
+
+            {{-- Recent Post --}}
+            @if($recentPosts->count() > 0)
+                <section class="container mx-auto px-6 py-12">
+                    <h2 class="text-xl font-bold mb-4">Berita Terkini</h2>
+                    <div class="flex flex-wrap gap-3">
+                        @foreach($recentPosts as $post)
+                            <a href="{{ route('news.detail', $post->id) }}"
+                               class="px-4 py-2 border border-gray-300 rounded-full text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-600">
+                                {{ $post->title }}
+                            </a>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
+        @endif
     </section>
-    @endif
 
 @endsection


### PR DESCRIPTION
This pull request improves the user experience and layout consistency across several Blade view files. The most significant updates include adding empty state messages for activities and news pages, making the navbar fixed for better accessibility, and adjusting layout spacing for hero sections. Additionally, there are minor formatting and code style improvements for better readability.

**User experience improvements:**

* Added an empty state message to the activities page to inform users when no activities are available (`resources/views/activities.blade.php`). [[1]](diffhunk://#diff-2893750f328f16330c4f82cebf3f0e206d970e4f2145ee91e32ad57d3e6463d2R16-R22) [[2]](diffhunk://#diff-2893750f328f16330c4f82cebf3f0e206d970e4f2145ee91e32ad57d3e6463d2R60)
* Added an empty state message to the news page to handle cases where there are no news items, highlights, or recent posts (`resources/views/news.blade.php`). [[1]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfR16-R23) [[2]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfR132-R133)

**Layout and accessibility enhancements:**

* Made the navbar fixed at the top of the page for persistent navigation (`resources/views/components/navbar.blade.php`).
* Added top padding (`pt-16`) to the hero sections on the about, contact, and home pages to account for the fixed navbar and improve visual spacing (`resources/views/about.blade.php`, `resources/views/contact.blade.php`, `resources/views/home/index.blade.php`). [[1]](diffhunk://#diff-a683626ed9d910da537564113fa14a0b2ecae8e76a49b220316987b0179a2399L6-R6) [[2]](diffhunk://#diff-95ff7d505de1e409850b420063c4d77efd31ad1de527cbdb6a30c6f6fbfae770L6-R6) [[3]](diffhunk://#diff-581984353a3a7141ddd6bfa70ea79de2ef9bafbdd23ba0727a22583c097f9f23L6-R6)

**Code formatting and minor improvements:**

* Improved code readability by reformatting long lines and adjusting indentation in multiple files, including about, home, activities, and news views. [[1]](diffhunk://#diff-a683626ed9d910da537564113fa14a0b2ecae8e76a49b220316987b0179a2399L114-R115) [[2]](diffhunk://#diff-a683626ed9d910da537564113fa14a0b2ecae8e76a49b220316987b0179a2399L142-R144) [[3]](diffhunk://#diff-581984353a3a7141ddd6bfa70ea79de2ef9bafbdd23ba0727a22583c097f9f23L28-R36) [[4]](diffhunk://#diff-2893750f328f16330c4f82cebf3f0e206d970e4f2145ee91e32ad57d3e6463d2L28-R36) [[5]](diffhunk://#diff-17e91329af2f40a57a589fe0aa40ffc243cdd168eecd6e8b2779f3464b065a54L21-R21) [[6]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL24-R33) [[7]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL38-L45) [[8]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL54-R64) [[9]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL84-R95) [[10]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL96-R108)