### PR TITLE
Enhance gallery and news pages with image hover effects

### DIFF
--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -38,18 +38,18 @@
         </div>
     </section>
 
-        {{-- Gallery --}}
     <section class="bg-gray-100 py-16">
         <div class="container mx-auto px-6">
             <h2 class="text-2xl font-bold text-center mb-10">Gallery</h2>
             <div class="grid md:grid-cols-3 gap-6">
                 @forelse($galleryImages as $item)
-                    <div class="block overflow-hidden rounded-lg shadow">
-                        <div class="relative h-60">
-                            <img src="{{ asset('storage/' . $item['image']) }}" 
-                                 alt="{{ $item['title'] }}" 
-                                 class="w-full h-full object-cover">
-                            <div class="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent flex items-end">
+                    <div class="block overflow-hidden rounded-lg shadow group">
+                        <div class="relative h-60 overflow-hidden">
+                            <img src="{{ asset('storage/' . $item['image']) }}"
+                                 alt="{{ $item['title'] }}"
+                                 class="w-full h-full object-cover transform transition-transform duration-300 group-hover:scale-110">
+                            <div
+                                class="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent flex items-end opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                                 <div class="p-4 text-white">
                                     <h3 class="font-medium">{{ $item['title'] }}</h3>
                                     <p class="text-sm opacity-80">
@@ -66,10 +66,12 @@
                 @endforelse
             </div>
             <div class="text-center mt-8">
-                <a href="{{ route('activities') }}" class="inline-block px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 mx-2">
+                <a href="{{ route('activities') }}"
+                   class="inline-block px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 mx-2">
                     Lihat Kegiatan
                 </a>
-                <a href="{{ route('news') }}" class="inline-block px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 mx-2">
+                <a href="{{ route('news') }}"
+                   class="inline-block px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 mx-2">
                     Lihat Berita
                 </a>
             </div>

--- a/resources/views/news.blade.php
+++ b/resources/views/news.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 
     {{-- Hero Section --}}
-    <section class="relative bg-cover bg-center h-[250px] flex items-center justify-center text-white pt-16"
+    <section class="relative bg-cover bg-center h-[250px] flex items-center justify-center text-white pt-16 mb-12"
              style="background-image: url('{{ asset('sekolah.png') }}')">
         <div class="bg-black bg-opacity-50 p-6 rounded-lg text-center">
             <h1 class="text-3xl md:text-4xl font-bold">Berita</h1>
@@ -12,7 +12,7 @@
     </section>
 
     {{-- Berita Baru --}}
-    <section class="container mx-auto px-6 py-12">
+    <section class="container mx-auto px-6 py-12 mb-12">
         @if($news->isEmpty() && !$highlight && $moreNews->isEmpty() && $recentPosts->isEmpty())
             <div class="flex flex-col items-center justify-center bg-gray-50 rounded-lg shadow p-6 min-h-[400px]">
                 <i class="fas fa-newspaper text-gray-400 text-6xl mb-4"></i>
@@ -20,17 +20,18 @@
                 <p class="text-gray-500 mt-2">Belum ada berita yang tersedia saat ini.</p>
             </div>
         @else
-            {{-- Berita Baru --}}
             <div class="flex justify-between items-center mb-6">
                 <h2 class="text-2xl font-bold">Berita Terbaru</h2>
             </div>
 
             <div class="grid md:grid-cols-3 gap-6">
                 @foreach($news as $item)
-                    <div class="bg-white shadow rounded-lg overflow-hidden">
+                    <div class="bg-white shadow rounded-lg overflow-hidden group">
                         @if($item->image)
-                            <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}"
-                                 class="w-full h-40 object-cover">
+                            <div class="overflow-hidden">
+                                <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}"
+                                     class="w-full h-40 object-cover transform transition-transform duration-300 group-hover:scale-110">
+                            </div>
                         @else
                             <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
                                 <span class="text-gray-500">No Image</span>
@@ -52,84 +53,86 @@
                     </div>
                 @endforeach
             </div>
-
-            {{-- Highlight Berita --}}
-            @if($highlight)
-                <section class="bg-gray-100 py-12">
-                    <div class="container mx-auto px-6">
-                        <h2 class="text-2xl font-bold mb-6">Sorotan</h2>
-                        <div class="grid md:grid-cols-2 gap-6 items-center">
-                            @if($highlight->image)
-                                <img src="{{ asset('storage/'.$highlight->image) }}" alt="{{ $highlight->title }}"
-                                     class="w-full rounded-lg shadow">
-                            @else
-                                <div class="w-full h-64 bg-gray-200 flex items-center justify-center rounded-lg">
-                                    <span class="text-gray-500">No Image</span>
-                                </div>
-                            @endif
-                            <div>
-                                <h2 class="text-2xl font-bold mb-3">{{ $highlight->title }}</h2>
-                                <p class="text-gray-500 text-sm mb-2">
-                                    {{ $highlight->published_at ? \Carbon\Carbon::parse($highlight->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
-                                </p>
-                                <p class="text-gray-700 mb-4">{{ Str::limit(strip_tags($highlight->content), 150) }}</p>
-                                <a href="{{ route('news.detail', $highlight->id) }}"
-                                   class="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
-                                    Baca Selengkapnya
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </section>
-            @endif
-
-            {{-- Berita Lainnya --}}
-            @if($moreNews->count() > 0)
-                <section class="container mx-auto px-6 py-12">
-                    <h2 class="text-2xl font-bold mb-6">Berita Lainnya</h2>
-                    <div class="grid md:grid-cols-3 gap-6">
-                        @foreach($moreNews as $item)
-                            <div class="bg-white shadow rounded-lg overflow-hidden">
-                                @if($item->image)
-                                    <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}"
-                                         class="w-full h-40 object-cover">
-                                @else
-                                    <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
-                                        <span class="text-gray-500">No Image</span>
-                                    </div>
-                                @endif
-                                <div class="p-4">
-                                    <h3 class="font-semibold text-lg mb-2">{{ $item->title }}</h3>
-                                    <p class="text-gray-500 text-sm mb-2">
-                                        {{ $item->published_at ? \Carbon\Carbon::parse($item->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
-                                    </p>
-                                    <p class="text-gray-600 text-sm mb-2 line-clamp-2">{{ Str::limit(strip_tags($item->content), 100) }}</p>
-                                    <a href="{{ route('news.detail', $item->id) }}"
-                                       class="text-blue-600 font-medium hover:underline">
-                                        Selengkapnya...
-                                    </a>
-                                </div>
-                            </div>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
-
-            {{-- Recent Post --}}
-            @if($recentPosts->count() > 0)
-                <section class="container mx-auto px-6 py-12">
-                    <h2 class="text-xl font-bold mb-4">Berita Terkini</h2>
-                    <div class="flex flex-wrap gap-3">
-                        @foreach($recentPosts as $post)
-                            <a href="{{ route('news.detail', $post->id) }}"
-                               class="px-4 py-2 border border-gray-300 rounded-full text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-600">
-                                {{ $post->title }}
-                            </a>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
         @endif
     </section>
+
+    {{-- Highlight Berita --}}
+    @if($highlight)
+        <section class="bg-gray-50 py-12 mb-12">
+            <div class="container mx-auto px-6">
+                <h2 class="text-2xl font-bold mb-6">Sorotan</h2>
+                <div class="grid md:grid-cols-2 gap-6 items-center">
+                    @if($highlight->image)
+                        <div class="overflow-hidden">
+                            <img src="{{ asset('storage/'.$highlight->image) }}" alt="{{ $highlight->title }}"
+                                 class="w-full rounded-lg shadow transform transition-transform duration-300 hover:scale-110">
+                        </div>
+                    @else
+                        <div class="w-full h-64 bg-gray-200 flex items-center justify-center rounded-lg">
+                            <span class="text-gray-500">No Image</span>
+                        </div>
+                    @endif
+                    <div>
+                        <h2 class="text-2xl font-bold mb-3">{{ $highlight->title }}</h2>
+                        <p class="text-gray-500 text-sm mb-2">
+                            {{ $highlight->published_at ? \Carbon\Carbon::parse($highlight->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
+                        </p>
+                        <p class="text-gray-700 mb-4">{{ Str::limit(strip_tags($highlight->content), 150) }}</p>
+                        <a href="{{ route('news.detail', $highlight->id) }}"
+                           class="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+                            Baca Selengkapnya
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    @endif
+
+    {{-- Berita Lainnya --}}
+    @if($moreNews->count() > 0)
+        <section class="container mx-auto px-6 py-12 mb-12">
+            <h2 class="text-2xl font-bold mb-6">Berita Lainnya</h2>
+            <div class="grid md:grid-cols-3 gap-6">
+                @foreach($moreNews as $item)
+                    <div class="bg-white shadow rounded-lg overflow-hidden">
+                        @if($item->image)
+                            <img src="{{ asset('storage/'.$item->image) }}" alt="{{ $item->title }}"
+                                 class="w-full h-40 object-cover">
+                        @else
+                            <div class="w-full h-40 bg-gray-200 flex items-center justify-center">
+                                <span class="text-gray-500">No Image</span>
+                            </div>
+                        @endif
+                        <div class="p-4">
+                            <h3 class="font-semibold text-lg mb-2">{{ $item->title }}</h3>
+                            <p class="text-gray-500 text-sm mb-2">
+                                {{ $item->published_at ? \Carbon\Carbon::parse($item->published_at)->format('d F Y') : 'Tanggal tidak tersedia' }}
+                            </p>
+                            <p class="text-gray-600 text-sm mb-2 line-clamp-2">{{ Str::limit(strip_tags($item->content), 100) }}</p>
+                            <a href="{{ route('news.detail', $item->id) }}"
+                               class="text-blue-600 font-medium hover:underline">
+                                Selengkapnya...
+                            </a>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </section>
+    @endif
+
+    {{-- Recent Post --}}
+    @if($recentPosts->count() > 0)
+        <section class="container mx-auto px-6 py-12">
+            <h2 class="text-xl font-bold mb-4">Berita Terkini</h2>
+            <div class="flex flex-wrap gap-3">
+                @foreach($recentPosts as $post)
+                    <a href="{{ route('news.detail', $post->id) }}"
+                       class="px-4 py-2 border border-gray-300 rounded-full text-sm text-gray-600 hover:bg-blue-50 hover:text-blue-600">
+                        {{ $post->title }}
+                    </a>
+                @endforeach
+            </div>
+        </section>
+    @endif
 
 @endsection


### PR DESCRIPTION
This pull request updates the user interface for the gallery and news pages to enhance visual interactivity and layout consistency. The main improvements include adding hover effects to images, improving section spacing, and cleaning up markup for better readability.

**UI/UX Improvements:**

* Added hover zoom effects to gallery and news images by wrapping images in a `group` and applying `transform scale-110` transitions, making the interface more dynamic and engaging. [[1]](diffhunk://#diff-581984353a3a7141ddd6bfa70ea79de2ef9bafbdd23ba0727a22583c097f9f23L41-R52) [[2]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL15-R34) [[3]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfR56-R69)
* Made overlay captions in the gallery appear smoothly on hover by transitioning opacity, improving user experience.
* Improved section spacing and visual separation by adding bottom margins (`mb-12`) to key sections like the news hero, latest news, highlights, and more news sections. [[1]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL6-R6) [[2]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL15-R34) [[3]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfR56-R69) [[4]](diffhunk://#diff-27f4ff026e89d67f8a40cc11c6daf61889700f5cbfdd8784504ee8c10eb994bfL88-R93)

**Code Cleanliness and Readability:**

* Reformatted anchor tags for better readability and consistency in the gallery section.
* Removed redundant Blade section endings and improved section structure in the news view.…section spacing